### PR TITLE
Use XHRLocal if origin is "null"

### DIFF
--- a/lib/info-receiver.js
+++ b/lib/info-receiver.js
@@ -32,7 +32,7 @@ inherits(InfoReceiver, EventEmitter);
 
 InfoReceiver._getReceiver = function(baseUrl, url, urlInfo) {
   // determine method of CORS support (if needed)
-  if (urlInfo.sameOrigin) {
+  if (urlInfo.sameOrigin || urlInfo.nullOrigin) {
     return new InfoAjax(url, XHRLocal);
   }
   if (XHRCors.enabled) {


### PR DESCRIPTION
Without that, we end up using XHRCors with credentials true. The problem is that on the server end, when origin is null we set "Access-Control-Allow-Origin: *" which fails when credentials is true.
